### PR TITLE
Require a space after, but not before, the colon in object key/values

### DIFF
--- a/config/jscs.hjson
+++ b/config/jscs.hjson
@@ -52,6 +52,10 @@
 	"requireSpacesInConditionalExpression": true,
 	"requireSpaceBeforeBlockStatements": true,
 	"requireLineFeedAtFileEnd": true,
+	"requireSpaceBeforeObjectValues": true,
+	"disallowSpaceAfterObjectKeys": {
+		"allExcept": ["aligned"]
+	},
 	"requireSpacesInsideObjectBrackets": { "allExcept": ["}"] },
 	"disallowSpacesInsideArrayBrackets": "all",
 	"disallowSpacesInsideParentheses": true,


### PR DESCRIPTION
I overlooked these JSCS rules previously. Here is the intent:

``` javascript
var foo = {
  a:1,   // invalid
  b : 2, // invalid
  c: 3   // valid
};

// valid because of alignment
var foo = {
  a    : 1,
  bbb  : 2,
  ccccc: 3
};
```
