### PR TITLE
Include dotfiles when linting JS.

### DIFF
--- a/linters/eslint.js
+++ b/linters/eslint.js
@@ -34,6 +34,7 @@ function linter(type, filePattern, opts) {
 	opts = extend(true, {}, config, opts);
 	var cli = new CLIEngine({
 		baseConfig: opts,
+		dotfiles: true,
 		fix: type === 'fix',
 		useEslintrc: false
 	});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node": ">=4.0.0"
   },
   "devDependencies": {
+    "del": "^2.2.2",
     "fs-extra": "^0.26.2",
     "jasmine": "^2.3.2",
     "proxyquire": "^1.7.3",

--- a/test/eslint-spec.js
+++ b/test/eslint-spec.js
@@ -1,7 +1,9 @@
 /* eslint no-console: "off" */
 'use strict';
 
+var del      = require('del');
 var fs       = require('fs-extra');
+var path     = require('path');
 var tempfile = require('tempfile');
 
 describe('eslint linter', function() {
@@ -59,6 +61,21 @@ describe('eslint linter', function() {
 			eslint.check(badFile, opts).then(function(results) {
 				expect(results).toEqual([]);
 				done();
+			});
+		});
+
+		it('should include dotfiles', function(done) {
+			var tempFolder = './.tmp';
+			var tempFile = path.join(tempFolder, goodFile);
+			fs.mkdirSync(tempFolder);
+			fs.copySync(goodFile, tempFile);
+			eslint.check(tempFile).then(function(results) {
+				expect(results).toEqual([]);
+				del.sync(tempFolder);
+				done();
+			}).catch(function(err) {
+				del.sync(tempFolder);
+				console.log('Error:', err.stack);
 			});
 		});
 


### PR DESCRIPTION
Uses the undocumented "dotfiles" option for ESLint. fixes #15
