### PR TITLE
Use "SwitchCase":1 for JS indentation.

### DIFF
--- a/config/eslint.hjson
+++ b/config/eslint.hjson
@@ -34,13 +34,13 @@
 			"func-call-spacing": ["error", "never"], // forbid space between function name and ()
 			"generator-star-spacing": ["error", "after"], // require space after "function*" generator
 			"guard-for-in": "error", // require "hasOwnProperty" check inside for..in loops
+			"indent": ["error", "tab", { "SwitchCase": 1 }], // tab indentation
 			"key-spacing": ["error", { // require space after a key's colon
 				"beforeColon": false,
 				"afterColon": true,
 				"mode": "minimum"
 			}],
 			"keyword-spacing": ["error", { "before": true, "after": true }], // require spaces around keywords
-			"indent": ["error", "tab"], // tab indentation
 			"linebreak-style": ["error", "unix"], // Unix EOLs
 			"max-len": ["error", 120], // no more than 120 chars per line
 			"new-cap": "error", // require constructors to be capitalized


### PR DESCRIPTION
Banno indents our `case` statements like this:

```javasacript
switch(a){
  case "a":
    break;
  case "b":
    break;
}
```

See http://eslint.org/docs/rules/indent#switchcase

Also fixed alphabetization of the rules.