### PR TITLE
Add usage statement

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,14 @@
 /* eslint no-console: "off" */
 'use strict';
 
+const USAGE_STATEMENT = `
+${process.argv[1]} [options] [file.js] [dir]
+
+Options:
+  --extend [path]         Use custom linter configuration file
+  --fix                   Automatically fix linting errors
+`;
+
 var chalk     = require('chalk');
 var extend    = require('extend');
 var linter    = require('./');
@@ -11,6 +19,11 @@ var reporter  = require('./reporters/stylish');
 
 var firstArgIndex = 2;
 var args = parseArgs(process.argv.slice(firstArgIndex));
+
+if (args.help) {
+  console.log(USAGE_STATEMENT);
+  process.exit();
+}
 
 var type = args.fix ? 'fix' : 'check';
 var files = (!args._ || args._.length === 0) ? ['src/**/*.js', '*.js'] : args._;

--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,7 @@
 /* eslint no-console: "off" */
 'use strict';
 
+/* eslint-disable indent */
 const USAGE_STATEMENT = `
 ${process.argv[1]} [options] [file.js,...] [dir,...]
 
@@ -9,6 +10,7 @@ Options:
   --extend [path]         Use custom linter configuration file
   --fix                   Automatically fix linting errors
 `;
+/* eslint-enable indent */
 
 var chalk     = require('chalk');
 var extend    = require('extend');
@@ -21,8 +23,8 @@ var firstArgIndex = 2;
 var args = parseArgs(process.argv.slice(firstArgIndex));
 
 if (args.help) {
-  console.log(USAGE_STATEMENT);
-  process.exit();
+	console.log(USAGE_STATEMENT);
+	process.exit();
 }
 
 var type = args.fix ? 'fix' : 'check';

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,7 @@
 
 /* eslint-disable indent */
 const USAGE_STATEMENT = `
-${process.argv[1]} [options] [file.js,...] [dir,...]
+ux-lint [options] [file.js ...] [dir ...]
 
 Options:
   --extend [path]         Use custom linter configuration file

--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const USAGE_STATEMENT = `
-${process.argv[1]} [options] [file.js] [dir]
+${process.argv[1]} [options] [file.js,...] [dir,...]
 
 Options:
   --extend [path]         Use custom linter configuration file


### PR DESCRIPTION
This adds a usage statement to be logged to the console when the user specifies the `--help` argument; if `--help` is specified, the usage statement is logged, then the process exits.