### PR TITLE
Add rule options for the various types of indentation.

### DIFF
--- a/config/eslint.hjson
+++ b/config/eslint.hjson
@@ -35,7 +35,17 @@
 		"func-call-spacing": ["error", "never"], // forbid space between function name and ()
 		"generator-star-spacing": ["error", "after"], // require space after "function*" generator
 		"guard-for-in": "error", // require "hasOwnProperty" check inside for..in loops
-		"indent": ["error", "tab", { "SwitchCase": 1 }], // tab indentation
+		"indent": ["error", "tab", { // tab indentation
+			"ArrayExpression": 1,
+			"CallExpression": { "arguments": 1 },
+			"FunctionDeclaration": { "body": 1, "parameters": 1 },
+			"FunctionExpression": { "body": 1, "parameters": 1 },
+			"MemberExpression": 1,
+			"ObjectExpression": 1,
+			"outerIIFEBody": 1,
+			"SwitchCase": 1,
+			"VariableDeclarator": 1
+		}],
 		"key-spacing": ["error", { // require space after a key's colon
 			"beforeColon": false,
 			"afterColon": true,


### PR DESCRIPTION
The basic `indent` option in ESLint only checks code blocks. This PR adds options to check all the other situations where indentation may be used.

For example, the following situations are now correctly flagged as errors:

```javascript
function(
	contactUsTemplate, // tabs (correct)
  giveFeedbackTemplate, // spaces (wrong)
  starRatingTemplate // more spaces
) { /* ... */ }
```

```javascript
return gulp.src('/highcharts/highcharts.js')
.pipe(gulp.dest(buildPath + '/js/lib/')); // chained member expressions should be indented
```

and others... see [the ESLint docs](http://eslint.org/docs/rules/indent) for the complete list.
