### PR TITLE
Include the rule's name in the "stylish" reporter output.

### DIFF
--- a/reporters/stylish.js
+++ b/reporters/stylish.js
@@ -29,6 +29,7 @@ module.exports = function(results, opts) {
 			'',
 			'',
 			chalk.gray(err.plugin),
+			chalk.gray(err.code),
 			chalk.gray('line ' + err.line),
 			chalk.gray('col ' + err.character),
 			isError ? chalk.red(err.description) : chalk.blue(err.description)


### PR DESCRIPTION
Include the name of the rule in the output of the linting errors. This will help when needing to research or quickly disable a rule.

Example output now:

<img width="786" alt="screen shot 2017-02-10 at 9 31 03 am" src="https://cloud.githubusercontent.com/assets/1656140/22832529/fc01ea76-ef73-11e6-8c0c-a7ae40d4c7bf.png">
