### PR TITLE
Updates ESLint rules for Banno Online and new projects.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,25 +12,25 @@ Options:
 `;
 /* eslint-enable indent */
 
-var chalk     = require('chalk');
-var extend    = require('extend');
-var linter    = require('./');
-var parseArgs = require('minimist');
-var parseJson = require('./helper').parseJson;
-var reporter  = require('./reporters/stylish');
+const chalk     = require('chalk');
+const extend    = require('extend');
+const linter    = require('./');
+const parseArgs = require('minimist');
+const parseJson = require('./helper').parseJson;
+const reporter  = require('./reporters/stylish');
 
-var firstArgIndex = 2;
-var args = parseArgs(process.argv.slice(firstArgIndex));
+const firstArgIndex = 2;
+const args = parseArgs(process.argv.slice(firstArgIndex));
 
 if (args.help) {
 	console.log(USAGE_STATEMENT);
 	process.exit();
 }
 
-var type = args.fix ? 'fix' : 'check';
-var files = (!args._ || args._.length === 0) ? ['src/**/*.js', '*.js'] : args._;
+let type = args.fix ? 'fix' : 'check';
+let files = (!args._ || args._.length === 0) ? ['src/**/*.js', '*.js'] : args._;
 
-var optFiles;
+let optFiles;
 if (typeof args.extend === 'undefined') {
 	optFiles = [];
 } else if (Array.isArray(args.extend)) {
@@ -39,11 +39,11 @@ if (typeof args.extend === 'undefined') {
 	optFiles = new Array(args.extend);
 }
 
-var opts = optFiles.reduce(function(prevVal, currentVal) {
+let opts = optFiles.reduce((prevVal, currentVal) => {
 	return extend({}, prevVal, parseJson(currentVal));
 }, {});
 
-linter[type](files, opts, function(err, results) {
+linter[type](files, opts, (err, results) => {
 	if (err) {
 		console.log(chalk.red('Error: ') + err.message + '\n');
 		console.log(err.stack);

--- a/config/eslint.hjson
+++ b/config/eslint.hjson
@@ -17,12 +17,14 @@
 	"rules": {
 		"array-bracket-spacing": ["error", "never"], // no spaces inside array brackets
 		"array-callback-return": "warn", // warn if array callbacks don't return values
+		"arrow-body-style": "off", // don't constrain our syntax for arrow functions
 		"arrow-spacing": ["error", { "before": true, "after": true }], // require spacing around fat-arrow operator
 		"accessor-pairs": "warn", // warn if getters/setters aren't paired
 		"block-scoped-var": "warn", // warn about confusing var hoisting
 		"block-spacing": ["error", "always"], // require spacing inside blocks
 		"brace-style": ["error", "1tbs", { "allowSingleLine": true }], // require "one true brace style"
 		"camelcase": "error", // require camelcase for names
+		"comma-dangle": "off", // unnecessary comma is ok
 		"comma-spacing": ["error", { "before": false, "after": true }], // require space after commas
 		"comma-style": ["error", "last"], // require commas at the end of lines
 		"complexity": "warn", // warn about code with high cyclomatic complexity
@@ -52,11 +54,15 @@
 			"mode": "minimum"
 		}],
 		"keyword-spacing": ["error", { "before": true, "after": true }], // require spaces around keywords
-		"linebreak-style": ["error", "unix"], // Unix EOLs
+		"linebreak-style": ["off"], // handled by VCS and editors
 		"max-depth": "warn", // warn about deeply-nested code
-		"max-len": ["error", 120], // no more than 120 chars per line
+		"max-len": ["error", 120, { // no more than 120 chars per line
+			"ignoreUrls": true // long URLs are ok
+		}],
 		"max-nested-callbacks": "warn", // warn about deeply-nested callbacks
-		"new-cap": "error", // require constructors to be capitalized
+		"new-cap": ["error", { // require constructors to be capitalized
+			"capIsNewExceptions": ["Polymer"]
+		}],
 		"new-parens": "error", // require parens when calling a constructor
 		"no-array-constructor": "error", // force literal notation for Array construction
 		"no-caller": "error", // forbid arguments.callee & arguments.caller
@@ -89,6 +95,7 @@
 		}],
 		"no-multi-str": "error", // forbid multiline strings
 		"no-multiple-empty-lines": "error", // forbid multiple blank lines
+		"no-negated-condition": "off", // allow negated conditions
 		"no-nested-ternary": "warn", // warn of nested ternary expressions
 		"no-new-func": "error", // forbid Function constructor
 		"no-new-object": "error", // force literal notation for Object construction
@@ -107,12 +114,18 @@
 		"no-unneeded-ternary": "error", // forbid unnecessary ternary expressions
 		"no-unused-expressions": "warn", // warn about unused expressions
 		"no-unused-vars": ["error", { "args": "none" }], // forbid unused vars, except as function args
+		"no-use-before-define": ["error", { // allow hoisting of functions and classes, but not variables
+			"functions": false,
+			"classes": false
+		}],
 		"no-useless-call": "error", // forbid unnecessary call()/apply()
 		"no-useless-computed-key": "error", // forbid computed keys
 		"no-useless-concat": "error", // forbid unnecessary string concatenation
 		"no-useless-escape": "error", // forbid unnecessary escape sequences
 		"no-useless-rename": "error", // forbid unnecessary import/export/destructuring renaming
 		"no-useless-return": "error", // forbid unnecessary return statements
+		"no-var": "error", // use let or const
+		"no-warning-comments": "off", // allow TODO/FIXME comments
 		"no-whitespace-before-property": "error", // forbid whitespace around property accessor
 		"no-with": "error", // forbid "with" expressions
 		"object-curly-spacing": ["error", "always", { // require spaces inside object braces, unless nested in another object
@@ -120,6 +133,11 @@
 		}],
 		"one-var": ["error", { "initialized": "never" }], // one "var" per var declaration, unless the var is uninitialized
 		"operator-linebreak": ["error", "after"], // require operator right before the line break
+		"prefer-arrow-callback": "warn", // shorter, with auto binding
+		"prefer-const": "off", // defer to the developer
+		"prefer-rest-params": "error", // use variadic functions
+		"prefer-spread": "error", // use spread rather than Function.prototype.apply()
+		"prefer-template": "off", // allow string concatenation
 		"quote-props": ["error", "as-needed"], // only quote properties when necessary
 		"quotes": ["error", "single"], // single quotes
 		"radix": "error", // require the radix argument to parseInt()
@@ -131,7 +149,7 @@
 		"space-infix-ops": "error", // require space around infix operators
 		"space-unary-ops": "error", // require space around "word" unary operators, but not "non-word" operators
 		"spaced-comment": ["error", "always"], // require space inside comment
-		"strict": ["error", "safe"], // require "use strict" directive
+		"strict": ["error", "global"], // require "use strict" directive at the top of files
 		"template-curly-spacing": "error", // forbid spaces inside template expression ${}
 		"unicode-bom": "error", // forbid BOM header
 		"wrap-iife": ["error", "inside"], // require IIFEs to be wrapped in parens

--- a/helper.js
+++ b/helper.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var fs    = require('fs');
-var glob  = require('globby');
-var hjson = require('hjson');
+const fs    = require('fs');
+const glob  = require('globby');
+const hjson = require('hjson');
 
 // Flattens an array of arrays.
-exports.flatten = function(arrayOfArrays) {
-	return arrayOfArrays.reduce(function(a, b) {
+exports.flatten = (arrayOfArrays) => {
+	return arrayOfArrays.reduce((a, b) => {
 		return a.concat(b);
 	}, []);
 };
 
 // Converts the argument into an array, if not already one.
-exports.toArray = function(a) {
+exports.toArray = (a) => {
 	return Array.isArray(a) ? a : [a];
 };
 
 // Parses an (H)JSON file.
-exports.parseJson = function(filename, opts) {
+exports.parseJson = (filename, opts) => {
 	opts = opts || {};
 	try {
 		return hjson.parse(fs.readFileSync(filename, 'utf8'));
@@ -32,24 +32,24 @@ exports.parseJson = function(filename, opts) {
 
 // Reads in the contents of files matching a pattern.
 // Returns a promise with an array of { file: ..., contents: ... } objects.
-exports.readFiles = function(filePattern) {
+exports.readFiles = (filePattern) => {
 	// Find all matching files.
-	var files = glob.sync(filePattern);
+	let files = glob.sync(filePattern);
 
 	if (files.length === 0) {
 		return Promise.resolve([]);
 	}
 
-	var isFile = function(file) {
-		var stat = fs.statSync(file);
+	const isFile = (file) => {
+		let stat = fs.statSync(file);
 		if (stat.isFile()) { return true; }
 		return false;
 	};
 
 	return Promise.all(
-		files.filter(isFile).map(function(file) {
-			return new Promise(function(resolve, reject) {
-				fs.readFile(file, 'utf8', function(err, contents) {
+		files.filter(isFile).map((file) => {
+			return new Promise((resolve, reject) => {
+				fs.readFile(file, 'utf8', (err, contents) => {
 					if (err) {
 						reject(new Error('could not read file ' + file + ': ' + err.message));
 						return;
@@ -65,7 +65,7 @@ exports.readFiles = function(filePattern) {
 };
 
 // Sort function for an array of linting errors.
-exports.sort = function(a, b) {
+exports.sort = (a, b) => {
 	// First sort by filename.
 	if (a.file < b.file) { return -1; }
 	if (a.file > b.file) { return 1; }

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var async   = require('async');
-var flatten = require('./helper').flatten;
-var toArray = require('./helper').toArray;
-var linters = require('require-all')({
+const async   = require('async');
+const flatten = require('./helper').flatten;
+const toArray = require('./helper').toArray;
+const linters = require('require-all')({
 	dirname: __dirname + '/linters'
 });
 
-exports.check = function(filePattern, opts, callback) {
+exports.check = (filePattern, opts, callback) => {
 	runLinters('check', filePattern, opts, callback);
 };
 
-exports.fix = function(filePattern, opts, callback) {
+exports.fix = (filePattern, opts, callback) => {
 	runLinters('fix', filePattern, opts, callback);
 };
 
@@ -20,15 +20,15 @@ function runLinters(type, filePattern, opts, callback) {
 	if (typeof callback === 'undefined') {
 		callback = opts;
 	}
-	var keys = Object.keys(linters);
-	async.map(keys, function(linterKey, asyncCallback) {
-		var linterOpts = opts[linterKey] || {};
-		linters[linterKey][type](filePattern, linterOpts).then(function(result) {
+	let keys = Object.keys(linters);
+	async.map(keys, (linterKey, asyncCallback) => {
+		let linterOpts = opts[linterKey] || {};
+		linters[linterKey][type](filePattern, linterOpts).then((result) => {
 			asyncCallback(null, result);
-		}).catch(function(err) {
+		}).catch((err) => {
 			asyncCallback(err);
 		});
-	}, function(err, results) {
+	}, (err, results) => {
 		if (err) {
 			callback(err);
 		} else {

--- a/linters/eslint.js
+++ b/linters/eslint.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var extend    = require('extend');
-var CLIEngine = require('eslint').CLIEngine;
-var flatten   = require('../helper').flatten;
-var parseJson = require('../helper').parseJson;
-var toArray   = require('../helper').toArray;
+const extend    = require('extend');
+const CLIEngine = require('eslint').CLIEngine;
+const flatten   = require('../helper').flatten;
+const parseJson = require('../helper').parseJson;
+const toArray   = require('../helper').toArray;
 
-var config = parseJson(__dirname + '/../config/eslint.hjson');
+const config = parseJson(__dirname + '/../config/eslint.hjson');
 
-exports.check = function(filePattern, opts) {
+exports.check = (filePattern, opts) => {
 	return linter('lint', filePattern, opts);
 };
 
 // Note that eslint's fix excludes the fixed items from the results.
-exports.fix = function(filePattern, opts) {
+exports.fix = (filePattern, opts) => {
 	return linter('fix', filePattern, opts);
 };
 
@@ -21,7 +21,7 @@ exports.fix = function(filePattern, opts) {
 // Returns the error messages, and includes the
 //   file path and code from the "result" object.
 function extractMessages(result) {
-	return result.messages.map(function(message) {
+	return result.messages.map((message) => {
 		return extend({}, message, {
 			filePath: result.filePath,
 			output: result.output
@@ -32,14 +32,14 @@ function extractMessages(result) {
 function linter(type, filePattern, opts) {
 	filePattern = toArray(filePattern);
 	opts = extend(true, {}, config, opts);
-	var cli = new CLIEngine({
+	let cli = new CLIEngine({
 		baseConfig: opts,
 		dotfiles: true,
 		fix: type === 'fix',
 		useEslintrc: false
 	});
-	var report = cli.executeOnFiles(filePattern);
-	var results = flatten(report.results.map(extractMessages)).map(function(result) {
+	let report = cli.executeOnFiles(filePattern);
+	let results = flatten(report.results.map(extractMessages)).map((result) => {
 		return {
 			character: result.column,
 			code: result.ruleId,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/Banno/ux-lint",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "devDependencies": {
     "del": "^2.2.2",

--- a/reporters/stylish.js
+++ b/reporters/stylish.js
@@ -4,28 +4,28 @@
 //
 /* eslint no-console: "off" */
 'use strict';
-var chalk        = require('chalk');
-var logSymbols   = require('log-symbols');
-var plur         = require('plur');
-var sortFunc     = require('../helper').sort;
-var stringLength = require('string-length');
-var table        = require('text-table');
+const chalk        = require('chalk');
+const logSymbols   = require('log-symbols');
+const plur         = require('plur');
+const sortFunc     = require('../helper').sort;
+const stringLength = require('string-length');
+const table        = require('text-table');
 
-module.exports = function(results, opts) {
-	var output = '';
-	var headers = [];
-	var prevfile;
-	var errorCount = 0;
-	var warningCount = 0;
+module.exports = (results, opts) => {
+	let output = '';
+	let headers = [];
+	let prevfile;
+	let errorCount = 0;
+	let warningCount = 0;
 
 	opts = opts || {};
 
 	results.sort(sortFunc);
 
-	output += table(results.map(function(err, i) {
-		var isError = err.type && err.type === 'error';
+	output += table(results.map((err, i) => {
+		let isError = err.type && err.type === 'error';
 
-		var line = [
+		let line = [
 			'',
 			'',
 			chalk.gray(err.plugin),
@@ -54,7 +54,7 @@ module.exports = function(results, opts) {
 		return line;
 	}), {
 		stringLength: stringLength
-	}).split('\n').map(function(line, i) {
+	}).split('\n').map((line, i) => {
 		return headers[i] ? '\n  ' + chalk.underline(headers[i]) + '\n' + line : line;
 	}).join('\n') + '\n\n';
 

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -1,30 +1,30 @@
 /* eslint no-console: "off" */
 'use strict';
 
-var fs       = require('fs-extra');
-var tempfile = require('tempfile');
+const fs       = require('fs-extra');
+const tempfile = require('tempfile');
 
-describe('JS API', function() {
+describe('JS API', () => {
 
-	var linter = require('../');
-	var customMatchers = require('./helpers/custom-matchers');
-	var badFile  = __dirname + '/fixtures/bad-javascript.js';
+	const linter = require('../');
+	const customMatchers = require('./helpers/custom-matchers');
+	const badFile  = __dirname + '/fixtures/bad-javascript.js';
 
-	beforeEach(function() {
+	beforeEach(() => {
 		jasmine.addMatchers(customMatchers);
 	});
 
-	describe('check()', function() {
+	describe('check()', () => {
 
-		it('should set the error object to null when successful', function(done) {
-			linter.check(badFile, function(err, results) {
+		it('should set the error object to null when successful', (done) => {
+			linter.check(badFile, (err, results) => {
 				expect(err).toBe(null);
 				done();
 			});
 		});
 
-		it('should return an array of linter errors', function(done) {
-			linter.check(badFile, function(err, results) {
+		it('should return an array of linter errors', (done) => {
+			linter.check(badFile, (err, results) => {
 				if (err) { console.log('Error:', err.message); }
 				expect(results).toEqual(jasmine.any(Array));
 				expect(results[0]).toBeLintError();
@@ -32,8 +32,8 @@ describe('JS API', function() {
 			});
 		});
 
-		it('should accept options as an optional argument', function(done) {
-			linter.check(badFile, {}, function(err, results) {
+		it('should accept options as an optional argument', (done) => {
+			linter.check(badFile, {}, (err, results) => {
 				if (err) { console.log('Error:', err.message); }
 				expect(results).toEqual(jasmine.any(Array));
 				expect(results[0]).toBeLintError();
@@ -41,8 +41,8 @@ describe('JS API', function() {
 			});
 		});
 
-		it('should return empty results if given a file pattern that doesn\'t match anything', function(done) {
-			linter.check('supercalifragilisticexpialidocious', function(err, results) {
+		it('should return empty results if given a file pattern that doesn\'t match anything', (done) => {
+			linter.check('supercalifragilisticexpialidocious', (err, results) => {
 				expect(err).toBe(null);
 				expect(results).toEqual([]);
 				done();
@@ -51,54 +51,54 @@ describe('JS API', function() {
 
 	});
 
-	describe('fix()', function() {
+	describe('fix()', () => {
 
-		var tempFilename;
-		var originalContents, fixedContents;
+		let tempFilename;
+		let originalContents, fixedContents;
 
-		beforeEach(function() {
+		beforeEach(() => {
 			tempFilename = tempfile('.js');
 			fs.copySync(badFile, tempFilename);
 			originalContents = fs.readFileSync(tempFilename, { encoding: 'utf8' });
 		});
 
-		afterEach(function() {
+		afterEach(() => {
 			fixedContents = fs.readFileSync(tempFilename, { encoding: 'utf8' });
 			fs.removeSync(tempFilename);
 		});
 
-		it('should set the error object to null when successful', function(done) {
-			linter.fix(tempFilename, function(err, results) {
+		it('should set the error object to null when successful', (done) => {
+			linter.fix(tempFilename, (err, results) => {
 				expect(err).toBe(null);
 				done();
 			});
 		});
 
-		it('should return an array', function(done) {
-			linter.fix(tempFilename, function(err, results) {
+		it('should return an array', (done) => {
+			linter.fix(tempFilename, (err, results) => {
 				if (err) { console.log('Error:', err.message); }
 				expect(results).toEqual(jasmine.any(Array));
 				done();
 			});
 		});
 
-		it('should update the file with the fixes', function(done) {
-			linter.fix(tempFilename, function(err, results) {
+		it('should update the file with the fixes', (done) => {
+			linter.fix(tempFilename, (err, results) => {
 				expect(fixedContents).not.toBe(originalContents);
 				done();
 			});
 		});
 
-		it('should accept options as an optional argument', function(done) {
-			linter.fix(tempFilename, {}, function(err, results) {
+		it('should accept options as an optional argument', (done) => {
+			linter.fix(tempFilename, {}, (err, results) => {
 				if (err) { console.log('Error:', err.message); }
 				expect(results).toEqual(jasmine.any(Array));
 				done();
 			});
 		});
 
-		it('should return empty results if given a file pattern that doesn\'t match anything', function(done) {
-			linter.check('supercalifragilisticexpialidocious', function(err, results) {
+		it('should return empty results if given a file pattern that doesn\'t match anything', (done) => {
+			linter.check('supercalifragilisticexpialidocious', (err, results) => {
 				expect(err).toBe(null);
 				expect(results).toEqual([]);
 				done();

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -1,16 +1,16 @@
 'use strict';
-describe('CLI', function() {
+describe('CLI', () => {
 
-	var extend = require('extend');
-	var proxyquire = require('proxyquire');
-	var stub = {};
+	const extend = require('extend');
+	const proxyquire = require('proxyquire');
+	let stub = {};
 
-	var checkFunc, fixFunc;
-	var loadCli = function() {
+	let checkFunc, fixFunc;
+	const loadCli = () => {
 		proxyquire('../cli', stub);
 	};
 
-	beforeEach(function() {
+	beforeEach(() => {
 		checkFunc = jasmine.createSpy('check()');
 		fixFunc = jasmine.createSpy('fix()');
 		stub['./'] = {
@@ -20,7 +20,7 @@ describe('CLI', function() {
 		stub['./reporters/stylish'] = jasmine.createSpy('reporter');
 	});
 
-	it('should lint the "src" folder in the current directory by default', function() {
+	it('should lint the "src" folder in the current directory by default', () => {
 		loadCli();
 		expect(checkFunc).toHaveBeenCalled();
 		expect(checkFunc.calls.mostRecent().args[0]).toEqual(['src/**/*.js', '*.js']);
@@ -28,63 +28,63 @@ describe('CLI', function() {
 		expect(checkFunc.calls.mostRecent().args[2]).toEqual(jasmine.any(Function));
 	});
 
-	it('should accept filenames for the source', function() {
-		var files = ['foo', 'bar'];
-		stub.minimist = function() { return { _: files }; };
+	it('should accept filenames for the source', () => {
+		const files = ['foo', 'bar'];
+		stub.minimist = () => { return { _: files }; };
 		loadCli();
 		expect(checkFunc).toHaveBeenCalled();
 		expect(checkFunc.calls.mostRecent().args[0]).toEqual(files);
 	});
 
-	it('should fix the files when passed the --fix flag', function() {
-		stub.minimist = function() { return { fix: true }; };
+	it('should fix the files when passed the --fix flag', () => {
+		stub.minimist = () => { return { fix: true }; };
 		loadCli();
 		expect(fixFunc).toHaveBeenCalled();
 	});
 
-	describe('--extend', function() {
+	describe('--extend', () => {
 
-		it('should read in the specified file', function() {
-			var opts = { foo: 'bar' };
-			stub.minimist = function() { return { extend: '1.json' }; };
-			stub['./helper'] = { parseJson: function() { return opts; } };
+		it('should read in the specified file', () => {
+			const opts = { foo: 'bar' };
+			stub.minimist = () => { return { extend: '1.json' }; };
+			stub['./helper'] = { parseJson: () => { return opts; } };
 			loadCli();
 			expect(checkFunc.calls.mostRecent().args[1]).toEqual(opts);
 		});
 
-		it('should work with multiple files', function() {
-			var i = 0;
-			var opts = [{ foo: 'bar' }, { foo: 'arb', foo2: 'baz' }];
-			stub.minimist = function() { return { extend: ['1.json', '2.json'] }; };
-			stub['./helper'] = { parseJson: function(filename) { return opts[i++]; } };
+		it('should work with multiple files', () => {
+			let i = 0;
+			const opts = [{ foo: 'bar' }, { foo: 'arb', foo2: 'baz' }];
+			stub.minimist = () => { return { extend: ['1.json', '2.json'] }; };
+			stub['./helper'] = { parseJson: (filename) => { return opts[i++]; } };
 			loadCli();
 			expect(checkFunc.calls.mostRecent().args[1]).toEqual(extend({}, opts[0], opts[1]));
 		});
 
 	});
 
-	describe('when there are no lint errors', function() {
+	describe('when there are no lint errors', () => {
 
-		beforeEach(function() {
-			checkFunc.and.callFake(function(files, opts, callback) {
+		beforeEach(() => {
+			checkFunc.and.callFake((files, opts, callback) => {
 				callback(null, []);
 			});
 			loadCli();
 		});
 
-		it('should return an exit code of 0', function() {
+		it('should return an exit code of 0', () => {
 			expect(process.exitCode).toBe(0);
 		});
 
 	});
 
-	describe('when there are lint errors', function() {
+	describe('when there are lint errors', () => {
 
-		var numErrors = 17;
+		const numErrors = 17;
 
-		beforeEach(function() {
-			checkFunc.and.callFake(function(files, opts, callback) {
-				var results = [];
+		beforeEach(() => {
+			checkFunc.and.callFake((files, opts, callback) => {
+				let results = [];
 				results.length = numErrors;
 				results.fill({});
 				callback(null, results);
@@ -92,7 +92,7 @@ describe('CLI', function() {
 			loadCli();
 		});
 
-		it('should return an exit code equal to the number of errors', function() {
+		it('should return an exit code equal to the number of errors', () => {
 			expect(process.exitCode).toBe(numErrors);
 		});
 

--- a/test/eslint-spec.js
+++ b/test/eslint-spec.js
@@ -1,56 +1,56 @@
 /* eslint no-console: "off" */
 'use strict';
 
-var del      = require('del');
-var fs       = require('fs-extra');
-var path     = require('path');
-var tempfile = require('tempfile');
+const del      = require('del');
+const fs       = require('fs-extra');
+const path     = require('path');
+const tempfile = require('tempfile');
 
-describe('eslint linter', function() {
+describe('eslint linter', () => {
 
-	var eslint = require('../linters/eslint');
-	var customMatchers = require('./helpers/custom-matchers');
+	const eslint = require('../linters/eslint');
+	const customMatchers = require('./helpers/custom-matchers');
 
-	var badFile  = __dirname + '/fixtures/bad-javascript.js';
-	var goodFile = __dirname + '/fixtures/good-javascript.js';
+	const badFile  = __dirname + '/fixtures/bad-javascript.js';
+	const goodFile = __dirname + '/fixtures/good-javascript.js';
 
-	beforeEach(function() {
+	beforeEach(() => {
 		jasmine.addMatchers(customMatchers);
 	});
 
-	describe('check()', function() {
+	describe('check()', () => {
 
-		it('should return a promise with an array of errors', function(done) {
-			eslint.check(badFile).then(function(results) {
+		it('should return a promise with an array of errors', (done) => {
+			eslint.check(badFile).then((results) => {
 				expect(results).toEqual(jasmine.any(Array));
 				expect(results.length).toBeGreaterThan(0);
 				done();
-			}).catch(function(err) {
+			}).catch((err) => {
 				console.log('Error:', err.stack);
 			});
 		});
 
-		it('should have the expected error signature', function(done) {
-			eslint.check(badFile).then(function(results) {
+		it('should have the expected error signature', (done) => {
+			eslint.check(badFile).then((results) => {
 				expect(results[0]).toBeLintError();
 				done();
-			}).catch(function(err) {
+			}).catch((err) => {
 				console.log('Error:', err.stack);
 
 			});
 		});
 
-		it('should return a promise with an empty array for lint-free files', function(done) {
-			eslint.check(goodFile).then(function(results) {
+		it('should return a promise with an empty array for lint-free files', (done) => {
+			eslint.check(goodFile).then((results) => {
 				expect(results).toEqual([]);
 				done();
-			}).catch(function(err) {
+			}).catch((err) => {
 				console.log('Error:', err.stack);
 			});
 		});
 
-		it('should accept options', function(done) {
-			var opts = {
+		it('should accept options', (done) => {
+			const opts = {
 				// ignore all the errors
 				rules: {
 					indent: 'off',
@@ -58,22 +58,22 @@ describe('eslint linter', function() {
 					'object-curly-spacing': 'off'
 				}
 			};
-			eslint.check(badFile, opts).then(function(results) {
+			eslint.check(badFile, opts).then((results) => {
 				expect(results).toEqual([]);
 				done();
 			});
 		});
 
-		it('should include dotfiles', function(done) {
-			var tempFolder = './.tmp';
-			var tempFile = path.join(tempFolder, goodFile);
+		it('should include dotfiles', (done) => {
+			const tempFolder = './.tmp';
+			const tempFile = path.join(tempFolder, goodFile);
 			fs.mkdirSync(tempFolder);
 			fs.copySync(goodFile, tempFile);
-			eslint.check(tempFile).then(function(results) {
+			eslint.check(tempFile).then((results) => {
 				expect(results).toEqual([]);
 				del.sync(tempFolder);
 				done();
-			}).catch(function(err) {
+			}).catch((err) => {
 				del.sync(tempFolder);
 				console.log('Error:', err.stack);
 			});
@@ -81,45 +81,45 @@ describe('eslint linter', function() {
 
 	});
 
-	describe('fix()', function() {
+	describe('fix()', () => {
 
-		var tempFilename;
-		var originalContents, fixedContents;
+		let tempFilename;
+		let originalContents, fixedContents;
 
-		beforeEach(function() {
+		beforeEach(() => {
 			tempFilename = tempfile('.js');
 			fs.copySync(badFile, tempFilename);
 			originalContents = fs.readFileSync(tempFilename, { encoding: 'utf8' });
 		});
 
-		afterEach(function() {
+		afterEach(() => {
 			fixedContents = fs.readFileSync(tempFilename, { encoding: 'utf8' });
 			fs.removeSync(tempFilename);
 		});
 
-		it('should return a promise with an array', function(done) {
-			eslint.fix(tempFilename).then(function(results) {
+		it('should return a promise with an array', (done) => {
+			eslint.fix(tempFilename).then((results) => {
 				expect(results).toEqual(jasmine.any(Array));
 				done();
-			}).catch(function(err) {
+			}).catch((err) => {
 				console.log('Error:', err.stack);
 			});
 		});
 
-		it('should include problems that cannot be fixed automatically', function(done) {
-			eslint.fix(tempFilename).then(function(results) {
+		it('should include problems that cannot be fixed automatically', (done) => {
+			eslint.fix(tempFilename).then((results) => {
 				expect(results.length).toBeGreaterThan(0);
 				done();
-			}).catch(function(err) {
+			}).catch((err) => {
 				console.log('Error:', err.stack);
 			});
 		});
 
-		it('should update the file with the fixes', function(done) {
-			eslint.fix(tempFilename).then(function(results) {
+		it('should update the file with the fixes', (done) => {
+			eslint.fix(tempFilename).then((results) => {
 				expect(fixedContents).not.toBe(originalContents);
 				done();
-			}).catch(function(err) {
+			}).catch((err) => {
 				console.log('Error:', err.stack);
 			});
 		});

--- a/test/fixtures/bad-javascript.js
+++ b/test/fixtures/bad-javascript.js
@@ -1,14 +1,13 @@
-(function() {
-	'use strict';
-
+'use strict';
+(() => {
 	onboarding.controller('createUserController', ['$scope', '$stateParams', '$state',
 	'usersService', function($scope, $stateParams, $state, usersService) {
 
 		$scope.createUser = function(user) {
-			usersService.createUser(user).then(function(result) {
+			usersService.createUser(user).then((result) => {
 				$scope.userCreated = true;
 				$state.go('userProfile', {id: result._id});
-			}, function() {
+			}, () => {
 				$scope.userCreated = false;
 			});
 

--- a/test/fixtures/good-javascript.js
+++ b/test/fixtures/good-javascript.js
@@ -1,7 +1,7 @@
+'use strict';
 (function(context) {
-	'use strict';
 	function foo() {
 		return '42';
 	}
 	context.foo = foo();
-})(this);
+})(window);

--- a/test/helper-spec.js
+++ b/test/helper-spec.js
@@ -1,26 +1,26 @@
 'use strict';
 
-var fs = require('fs');
+const fs = require('fs');
 
-describe('helper functions', function() {
+describe('helper functions', () => {
 
-	describe('flatten()', function() {
+	describe('flatten()', () => {
 
-		var flatten = require('../helper').flatten;
+		const flatten = require('../helper').flatten;
 
-		it('should throw an error if argument is not an array', function() {
-			expect(function() {
+		it('should throw an error if argument is not an array', () => {
+			expect(() => {
 				flatten(null);
 			}).toThrow();
 		});
 
-		it('should return the array unchanged if there are no nested arrays', function() {
+		it('should return the array unchanged if there are no nested arrays', () => {
 			/* eslint-disable no-magic-numbers */
 			expect(flatten([1, 2, 3])).toEqual([1, 2, 3]);
 			/* eslint-enable no-magic-numbers */
 		});
 
-		it('should flatten an array of arrays', function() {
+		it('should flatten an array of arrays', () => {
 			/* eslint-disable no-magic-numbers */
 			expect(flatten([[1, 2], [3, 4], 5])).toEqual([1, 2, 3, 4, 5]);
 			/* eslint-enable no-magic-numbers */
@@ -28,53 +28,53 @@ describe('helper functions', function() {
 
 	});
 
-	describe('parseJson()', function() {
+	describe('parseJson()', () => {
 
-		var parseJson = require('../helper').parseJson;
+		const parseJson = require('../helper').parseJson;
 
-		it('should parse an HJSON file', function() {
-			var parsed = parseJson(__dirname + '/../config/eslint.hjson');
+		it('should parse an HJSON file', () => {
+			const parsed = parseJson(__dirname + '/../config/eslint.hjson');
 			expect(parsed).toEqual(jasmine.any(Object));
 			expect(parsed.globals).toBeDefined();
 		});
 
-		it('should throw an error if the file does not exist', function() {
-			expect(function() {
+		it('should throw an error if the file does not exist', () => {
+			expect(() => {
 				parseJson('nonexistent.json');
 			}).toThrow();
 		});
 
-		it('should NOT throw an error if "ignoreErrors" is set', function() {
-			expect(function() {
+		it('should NOT throw an error if "ignoreErrors" is set', () => {
+			expect(() => {
 				parseJson('nonexistent.json', { ignoreErrors: true });
 			}).not.toThrow();
 		});
 
 	});
 
-	describe('readFiles()', function() {
+	describe('readFiles()', () => {
 
-		var readFiles = require('../helper').readFiles;
-		var filename, contents;
+		const readFiles = require('../helper').readFiles;
+		let filename, contents;
 
-		beforeEach(function() {
+		beforeEach(() => {
 			filename = __dirname + '/fixtures/bad-javascript.js';
 			contents = fs.readFileSync(filename, 'utf8');
 		});
 
-		it('should return a promise', function() {
+		it('should return a promise', () => {
 			expect(readFiles(filename)).toEqual(jasmine.any(Promise));
 		});
 
-		it('should filter out non-files', function(done) {
-			readFiles('.').then(function(results) {
+		it('should filter out non-files', (done) => {
+			readFiles('.').then((results) => {
 				expect(results).toEqual([]);
 				done();
 			});
 		});
 
-		it('should resolve to an array with the file contents object', function(done) {
-			readFiles(filename).then(function(results) {
+		it('should resolve to an array with the file contents object', (done) => {
+			readFiles(filename).then((results) => {
 				expect(results).toEqual(jasmine.any(Array));
 				expect(results.length).toBe(1);
 				expect(results[0].file).toBe(filename);
@@ -83,27 +83,27 @@ describe('helper functions', function() {
 			});
 		});
 
-		it('should resolve to an empty array if there are no matching files', function(done) {
-			readFiles('nonmatching.pattern').then(function(results) {
+		it('should resolve to an empty array if there are no matching files', (done) => {
+			readFiles('nonmatching.pattern').then((results) => {
 				expect(results).toEqual([]);
 				done();
 			});
 		});
 
-		it('should support an array of patterns', function(done) {
-			var files = [
+		it('should support an array of patterns', (done) => {
+			const files = [
 				'test/fixtures/bad-javascript.js',
 				'test/fixtures/good-javascript.js'
 			];
-			readFiles(files).then(function(results) {
+			readFiles(files).then((results) => {
 				expect(results).toEqual(jasmine.any(Array));
 				expect(results.length).toBe(files.length);
 				done();
 			});
 		});
 
-		it('should resolve to an empty array if an invalid pattern is used', function(done) {
-			readFiles(null).then(function(results) {
+		it('should resolve to an empty array if an invalid pattern is used', (done) => {
+			readFiles(null).then((results) => {
 				expect(results).toEqual([]);
 				done();
 			});
@@ -111,13 +111,13 @@ describe('helper functions', function() {
 
 	});
 
-	describe('sort()', function() {
+	describe('sort()', () => {
 
-		var sortFunc = require('../helper').sort;
+		const sortFunc = require('../helper').sort;
 
-		var errors, expected;
+		let errors, expected;
 
-		beforeEach(function() {
+		beforeEach(() => {
 			errors = [
 				{ file: 'a', line: 67, character: 84, plugin: 'jshint' },
 				{ file: 'a', line: 41, character: 100, plugin: 'jshint' },
@@ -149,7 +149,7 @@ describe('helper functions', function() {
 			];
 		});
 
-		it('should sort arrays by file, line, column, then plugin', function() {
+		it('should sort arrays by file, line, column, then plugin', () => {
 			errors.sort(sortFunc);
 			expect(errors).toEqual(expected);
 		});

--- a/test/helpers/custom-matchers.js
+++ b/test/helpers/custom-matchers.js
@@ -3,7 +3,7 @@ module.exports = {
 	toBeLintError: function(util, customEqualityTesters) {
 		return {
 			compare: function(actual) {
-				var expectedProps = [
+				const expectedProps = [
 					'character',
 					'code',
 					'description',
@@ -13,8 +13,8 @@ module.exports = {
 					'plugin',
 					'type',
 				];
-				var actualProps = Object.keys(actual).sort();
-				var result = {
+				let actualProps = Object.keys(actual).sort();
+				let result = {
 					pass: util.equals(actualProps, expectedProps)
 				};
 				return result;


### PR DESCRIPTION
Updates the [JS linting rules](https://github.com/Banno/ux-lint/pull/23/files#diff-67932c31084db877adbf75c83197815c) on 3 fronts:

## Move to ES6

* `no-var`: `error` -- use `let` or `const` instead
* `prefer-arrow-callback`: `warn` -- arrow functions are preferred for callbacks
* `prefer-rest-params`: `error` -- use variadic functions
* `prefer-spread`: `error` -- use spread rather than `Function.prototype.apply()`

## Match what Banno Online uses

* `linebreak-style`: `off` -- handled by VCS and editors
* `max-len` option `ignoreUrls`: `true` -- long URLs are okay
* `new-cap` option `capIsNewExceptions`: `["Polymer"]` -- `Polymer` doesn't take `new`
* `strict`: `["error", "global"]` -- require "use strict" directive at the top of files; files are either ES6 modules or compiled into function-based modules

## Stress the defaults

* `arrow-body-style`: `off` -- don't constrain our syntax for arrow functions
* `comma-dangle`: `off` -- unnecessary comma is okay
* `no-negated-condition`: `off` -- allow negated conditions
* `no-use-before-define`: `"error", { "functions": false, "classes": false }]` -- allow hoisting of functions and classes, but not variables (matches [Angular style guidelines](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md))
* `no-warning-comments`: `off` -- allow TODO/FIXME comments
* `prefer-const`: `off` -- defer to the developer on when to use `const` vs `let`
* `prefer-template`: `off` -- allow string concatenation

## Notes

The project itself was updated to work with these changes, and was marked in the `package.json` as requiring Node.js v6+.

The rules obviously won't work with many of our current projects (platform etc) until they are written in ES6 and have more modern build tools.
