### PR TITLE
Add eslint-plugin-banno to the ESLint config.

### DIFF
--- a/config/eslint.hjson
+++ b/config/eslint.hjson
@@ -7,6 +7,7 @@
 		"protractor": true
 	},
 	"extends": "eslint:recommended",
+	"plugins": ["banno"],
 	"globals": {
 		"angular": false,
 		// Angular mocks
@@ -20,6 +21,7 @@
 		"arrow-body-style": "off", // don't constrain our syntax for arrow functions
 		"arrow-spacing": ["error", { "before": true, "after": true }], // require spacing around fat-arrow operator
 		"accessor-pairs": "warn", // warn if getters/setters aren't paired
+		"banno/no-for-const": "error",
 		"block-scoped-var": "warn", // warn about confusing var hoisting
 		"block-spacing": ["error", "always"], // require spacing inside blocks
 		"brace-style": ["error", "1tbs", { "allowSingleLine": true }], // require "one true brace style"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "async": "^1.5.0",
     "chalk": "^1.1.1",
     "eslint": "^3.9.1",
+    "eslint-plugin-banno": "^1.0.0",
     "extend": "^3.0.0",
     "globby": "^4.0.0",
     "hjson": "^1.7.4",

--- a/test/eslint-spec.js
+++ b/test/eslint-spec.js
@@ -53,6 +53,7 @@ describe('eslint linter', () => {
 			const opts = {
 				// ignore all the errors
 				rules: {
+					'banno/no-for-const': 'off',
 					indent: 'off',
 					'no-undef': 'off',
 					'object-curly-spacing': 'off'

--- a/test/fixtures/bad-javascript.js
+++ b/test/fixtures/bad-javascript.js
@@ -2,6 +2,9 @@
 (() => {
 	onboarding.controller('createUserController', ['$scope', '$stateParams', '$state',
 	'usersService', function($scope, $stateParams, $state, usersService) {
+		for (const param of $stateParams) {
+			param.foo = 'foo';
+		}
 
 		$scope.createUser = function(user) {
 			usersService.createUser(user).then((result) => {


### PR DESCRIPTION
This PR adds the `no-for-const` rule from Banno Online into the default ESLint configuration.

## Testing

`npm run lint` and `npm test` should have no errors.
