### PR TITLE
Add checkCode() and fixCode()

### DIFF
--- a/PR notes.txt
+++ b/PR notes.txt
@@ -1,8 +1,0 @@
-## TODO html linting
-
-HTMLTidy? https://github.com/c0b41/htmltidy2
-
-* fork lib (move custom rules into here)
-* whitelist for tagname-lowercase (clipPath)
-* "cannot be use" language
-* misleading message for <img src="[[imageDataUri]]" alt=""></img>

--- a/PR notes.txt
+++ b/PR notes.txt
@@ -1,0 +1,8 @@
+## TODO html linting
+
+HTMLTidy? https://github.com/c0b41/htmltidy2
+
+* fork lib (move custom rules into here)
+* whitelist for tagname-lowercase (clipPath)
+* "cannot be use" language
+* misleading message for <img src="[[imageDataUri]]" alt=""></img>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ The first argument can be a file, file pattern, or array of those.
 
 The configuration object passed as the 2nd argument will override (not replace) the default configuration.
 
+You can also check/fix code directly:
+
+```javascript
+linter.checkCode('// code here', { /* optional config, keyed by plugin name */ }, function(err, lintErrors) {
+  // `err` is the Error object, if an error occurred
+  // `lintErrors` is an array of linting errors
+});
+
+linter.fixCode('// code here', { /* optional config */ }, function(err, fixedCode) {
+  // `err` is in the same format as the checkCode() callback
+  // `fixedCode` is the source code with the fixes
+});
+```
+
 ## Contributing
 
 Want to propose a change to our style (and therefore linting) conventions? Want to add another linting tool? Pull requests and suggestions are welcome.
@@ -67,9 +81,11 @@ npm test      # run tests
 Each linter has a plugin in the `linters` folder. Plugins have the following signature:
 
 ```javascript
-// Both methods return a promise that resolves to an array.
+// All methods return a promise that resolves to an array (or string, in the case of fixCode()).
 exports.check = function(filePattern, opts) { /* ... */ };
 exports.fix   = function(filePattern, opts) { /* ... */ };
+exports.checkCode = function(codeString, opts) { /* ... */ };
+exports.fixCode   = function(codeString, opts) { /* ... */ };
 ```
 
 The results array should contain objects with the following signature:
@@ -83,7 +99,7 @@ The results array should contain objects with the following signature:
   line: 13, // line number of the offending code
   character: 9, // column number of the offending code
   description: '\'console\' is not defined.', // message about the error
-  file: '/Users/jdoe/bad-javascript.js' // filename
+  file: '/Users/jdoe/bad-javascript.js' // filename (check() and fix() only)
 }
 ```
 

--- a/helper.js
+++ b/helper.js
@@ -4,6 +4,12 @@ const fs    = require('fs');
 const glob  = require('globby');
 const hjson = require('hjson');
 
+// Capitalizes the first letter in a string.
+exports.capitalize = (str) => {
+	if (str === '') { return str; }
+	return str[0].toUpperCase() + str.substr(1);
+};
+
 // Flattens an array of arrays.
 exports.flatten = (arrayOfArrays) => {
 	return arrayOfArrays.reduce((a, b) => {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const async = require('async');
-const { flatten, toArray } = require('./helper');
+const { flatten } = require('./helper');
 const linters = require('require-all')({
 	dirname: __dirname + '/linters'
 });
@@ -10,28 +10,77 @@ exports.check = (filePattern, opts, callback) => {
 	runLinters('check', filePattern, opts, callback);
 };
 
+exports.checkCode = (code, opts, callback) => {
+	runLinters('checkCode', code, opts, callback);
+};
+
 exports.fix = (filePattern, opts, callback) => {
 	runLinters('fix', filePattern, opts, callback);
 };
 
-function runLinters(type, filePattern, opts, callback) {
-	filePattern = toArray(filePattern);
+exports.fixCode = (code, opts, callback) => {
+	runLinters('fixCode', code, opts, callback);
+};
+
+// Run all the linters in parallel and collect the results.
+// If fixing files, run in series (synchronously) to prevent
+//   file write conflicts.
+// If fixing code, run in waterfall flow to pass the results
+//   from one linter to the next.
+function runLinters(type, fileOrCode, opts, callback) {
 	if (typeof callback === 'undefined') {
 		callback = opts;
 	}
-	let keys = Object.keys(linters);
-	async.map(keys, (linterKey, asyncCallback) => {
-		let linterOpts = opts[linterKey] || {};
-		linters[linterKey][type](filePattern, linterOpts).then((result) => {
-			asyncCallback(null, result);
+
+	// Save the list of linters.
+	let linterNames = Object.keys(linters);
+
+	// Function for normal linting & fixing files.
+	let lintByName = (linterName, callback) => {
+		let linterOpts = opts[linterName] || {};
+		linters[linterName][type](fileOrCode, linterOpts).then(result => {
+			callback(null, result);
 		}).catch((err) => {
-			asyncCallback(err);
+			callback(err);
 		});
-	}, (err, results) => {
+	};
+
+	// Function for fixing code. It passes the result to the next one in series.
+	let createLintingFunc = linterName => {
+		return function(source, callback) {
+			let linterOpts = opts[linterName] || {};
+			linters[linterName][type](source, linterOpts).then(result => {
+				callback(null, result);
+			}).catch((err) => {
+				callback(err);
+			});
+		};
+	};
+
+	// Handles the final results.
+	let handleResults = (err, results) => {
 		if (err) {
 			callback(err);
 		} else {
-			callback(null, flatten(results));
+			callback(null, Array.isArray(results) ? flatten(results) : results);
 		}
-	});
+	};
+
+	// Define the method and arguments to pass to the async module.
+	let asyncMethod, args;
+	if (type === 'fix') {
+		asyncMethod = 'mapSeries';
+		args = [linterNames, lintByName, handleResults];
+	} else if (type === 'fixCode') {
+		asyncMethod = 'waterfall';
+		let funcs = linterNames.map(createLintingFunc);
+		funcs.unshift(callback => { callback(null, fileOrCode); }); // prime the pump with the initial code
+		args = [funcs, handleResults];
+	} else {
+		asyncMethod = 'map';
+		args = [linterNames, lintByName, handleResults];
+	}
+
+	// Run the linters.
+	async[asyncMethod](...args);
 }

--- a/linters/polymer.js
+++ b/linters/polymer.js
@@ -2,37 +2,25 @@
 
 const Linter = require('polymer-lint');
 const filterErrors = require('polymer-lint/lib/util/filterErrors');
-const { flatten, parseJson, readFiles, toArray } = require('../helper');
+const { capitalize, flatten, parseJson, readFiles, toArray } = require('../helper');
+const { PassThrough } = require('stream');
 
 const allRules = require('polymer-lint/lib/rules');
 const config = parseJson(__dirname + '/../config/polymer.hjson');
 
 exports.check = (filePattern, opts) => {
-	filePattern = toArray(filePattern);
-	opts = Object.assign({}, config, opts);
-	let rules = buildRules(opts && opts.rules);
-	let linter = new Linter(rules, opts);
-	return readFiles(filePattern).then(fileInfo => {
-		// Run the linter against Polymer files.
-		let files = fileInfo.filter(isPolymerFile).map(items => items.file);
-		return linter.lintFiles(files);
-	}).then(results => {
-		// Get the linter errors, filtering out those ignored by bplint directives.
-		const getErrors = result => {
-			return filterErrors(result.errors, result.context.stack).map(error => {
-				error.context = result.context;
-				return error;
-			});
-		};
-		return flatten(results.map(getErrors));
-	}).then(errors => {
-		// Format the errors to match the ux-lint specs.
-		return errors.map(formatResult);
-	});
+	return linter('files', filePattern, opts);
+};
+
+exports.checkCode = (code, opts) => {
+	return linter('text', code, opts);
 };
 
 // polymer-lint doesn't have fix functionality.
 exports.fix = exports.check;
+exports.fixCode = (code, opts) => {
+	return Promise.resolve(code);
+};
 
 // Builds a rules object for polymer-lint,
 //   based on the ux-lint rules definition.
@@ -71,4 +59,49 @@ function formatResult(error) {
 // It checks this by looking for a <dom-module> element in HTML files.
 function isPolymerFile(fileInfo) {
 	return /\.html$/.test(fileInfo.file) && /<dom-module/i.test(fileInfo.contents);
+}
+
+// Main function for linting.
+//   `sourceType` is "files" or "text"
+function linter(sourceType, filesOrCode, opts) {
+	opts = Object.assign({}, config, opts);
+
+	let rules = buildRules(opts && opts.rules);
+	let linter = new Linter(rules, opts);
+
+	let getSource = () => {
+		if (sourceType === 'text') {
+			let stream = new PassThrough();
+			stream.end(filesOrCode);
+			return Promise.resolve(stream);
+		}
+
+		filesOrCode = toArray(filesOrCode);
+		return readFiles(filesOrCode).then(fileInfo => {
+			return fileInfo.filter(isPolymerFile).map(items => items.file);
+		});
+	};
+
+	return getSource().then(source => {
+		let lintMethod = `lint${capitalize(sourceType === 'text' ? 'stream' : sourceType)}`;
+		return linter[lintMethod](source, {});
+	}).then(results => {
+		if (sourceType === 'text') {
+			// Wrap the response in an array for the next block.
+			return [results];
+		}
+		return results;
+	}).then(results => {
+		// Get the linter errors, filtering out those ignored by bplint directives.
+		const getErrors = result => {
+			return filterErrors(result.errors, result.context.stack).map(error => {
+				error.context = result.context;
+				return error;
+			});
+		};
+		return flatten(results.map(getErrors));
+	}).then(errors => {
+		// Format the errors to match the ux-lint specs.
+		return errors.map(formatResult);
+	});
 }

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -8,7 +8,11 @@ describe('JS API', () => {
 
 	const linter = require('../');
 	const customMatchers = require('./helpers/custom-matchers');
-	const badFile  = __dirname + '/fixtures/bad-javascript.js';
+
+	const badFile = __dirname + '/fixtures/bad-javascript.js';
+	const badCode = fs.readFileSync(badFile, 'utf8');
+	const fixedFile = __dirname + '/fixtures/fixed-javascript.js';
+	const fixedCode = fs.readFileSync(fixedFile, 'utf8');
 
 	beforeEach(() => {
 		jasmine.addMatchers(customMatchers);
@@ -51,15 +55,43 @@ describe('JS API', () => {
 
 	});
 
+	describe('checkCode()', () => {
+
+		it('should set the error object to null when successful', (done) => {
+			linter.checkCode(badCode, (err, results) => {
+				expect(err).toBe(null);
+				done();
+			});
+		});
+
+		it('should return an array of linter errors', (done) => {
+			linter.checkCode(badCode, (err, results) => {
+				if (err) { console.log('Error:', err.message); }
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results[0]).toBeLintError();
+				done();
+			});
+		});
+
+		it('should accept options as an optional argument', (done) => {
+			linter.checkCode(badCode, {}, (err, results) => {
+				if (err) { console.log('Error:', err.message); }
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results[0]).toBeLintError();
+				done();
+			});
+		});
+
+	});
+
 	describe('fix()', () => {
 
 		let tempFilename;
-		let originalContents, fixedContents;
+		let fixedContents;
 
 		beforeEach(() => {
 			tempFilename = tempfile('.js');
 			fs.copySync(badFile, tempFilename);
-			originalContents = fs.readFileSync(tempFilename, { encoding: 'utf8' });
 		});
 
 		afterEach(() => {
@@ -84,7 +116,7 @@ describe('JS API', () => {
 
 		it('should update the file with the fixes', (done) => {
 			linter.fix(tempFilename, (err, results) => {
-				expect(fixedContents).not.toBe(originalContents);
+				expect(fixedContents).toBe(fixedCode);
 				done();
 			});
 		});
@@ -101,6 +133,40 @@ describe('JS API', () => {
 			linter.check('supercalifragilisticexpialidocious', (err, results) => {
 				expect(err).toBe(null);
 				expect(results).toEqual([]);
+				done();
+			});
+		});
+
+	});
+
+	describe('fixCode()', () => {
+
+		it('should set the error object to null when successful', (done) => {
+			linter.fixCode(badCode, (err, results) => {
+				expect(err).toBe(null);
+				done();
+			});
+		});
+
+		it('should return a string', (done) => {
+			linter.fixCode(badCode, (err, results) => {
+				if (err) { console.log('Error:', err.message); }
+				expect(results).toEqual(jasmine.any(String));
+				done();
+			});
+		});
+
+		it('should update the file with the fixes', (done) => {
+			linter.fixCode(badCode, (err, results) => {
+				expect(results).toBe(fixedCode);
+				done();
+			});
+		});
+
+		it('should accept options as an optional argument', (done) => {
+			linter.fixCode(badCode, {}, (err, results) => {
+				if (err) { console.log('Error:', err.message); }
+				expect(results).toBe(fixedCode);
 				done();
 			});
 		});

--- a/test/eslint-spec.js
+++ b/test/eslint-spec.js
@@ -12,7 +12,11 @@ describe('eslint linter', () => {
 	const customMatchers = require('./helpers/custom-matchers');
 
 	const badFile  = __dirname + '/fixtures/bad-javascript.js';
+	const badCode  = fs.readFileSync(badFile, 'utf8');
+	const fixedFile = __dirname + '/fixtures/fixed-javascript.js';
+	const fixedCode = fs.readFileSync(fixedFile, 'utf8');
 	const goodFile = __dirname + '/fixtures/good-javascript.js';
+	const goodCode = fs.readFileSync(goodFile, 'utf8');
 	const htmlFile = __dirname + '/fixtures/good-html.html';
 
 	beforeEach(() => {
@@ -92,6 +96,54 @@ describe('eslint linter', () => {
 
 	});
 
+	describe('checkCode()', () => {
+
+		it('should return a promise with an array of errors', (done) => {
+			eslint.checkCode(badCode).then((results) => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBeGreaterThan(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should have the expected error signature', (done) => {
+			eslint.checkCode(badCode).then((results) => {
+				expect(results[0]).toBeLintError();
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should return a promise with an empty array for lint-free code', (done) => {
+			eslint.checkCode(goodCode).then((results) => {
+				expect(results).toEqual([]);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should accept options', (done) => {
+			const opts = {
+				// ignore all the errors
+				rules: {
+					'banno/no-for-const': 'off',
+					indent: 'off',
+					'no-undef': 'off',
+					'object-curly-spacing': 'off'
+				}
+			};
+			eslint.checkCode(badCode, opts).then((results) => {
+				expect(results).toEqual([]);
+				done();
+			});
+		});
+
+	});
+
 	describe('fix()', () => {
 
 		let tempFilename;
@@ -129,6 +181,37 @@ describe('eslint linter', () => {
 		it('should update the file with the fixes', (done) => {
 			eslint.fix(tempFilename).then((results) => {
 				expect(fixedContents).not.toBe(originalContents);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+	});
+
+	describe('fixCode()', () => {
+
+		it('should return a promise with a string', (done) => {
+			eslint.fixCode(badCode).then((results) => {
+				expect(results).toEqual(jasmine.any(String));
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should return a promise with the same code for lint-free code', (done) => {
+			eslint.fixCode(goodCode).then((results) => {
+				expect(results).toBe(goodCode);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should return a promise with the changed code for bad code', (done) => {
+			eslint.fixCode(badCode).then((results) => {
+				expect(results).toBe(fixedCode);
 				done();
 			}).catch((err) => {
 				console.log('Error:', err.stack);

--- a/test/fixtures/fixed-javascript.js
+++ b/test/fixtures/fixed-javascript.js
@@ -1,19 +1,19 @@
 'use strict';
 (() => {
-	onboarding.controller('createUserController', ['$scope', '$stateParams', '$state',
-		'usersService', function($scope, $stateParams, $state, usersService) {
-			for (let param of $stateParams) {
-				param.foo = 'foo';
-			}
+  onboarding.controller('createUserController', ['$scope', '$stateParams', '$state',
+    'usersService', function($scope, $stateParams, $state, usersService) {
+      for (let param of $stateParams) {
+        param.foo = 'foo';
+      }
 
-			$scope.createUser = function(user) {
-				usersService.createUser(user).then((result) => {
-					$scope.userCreated = true;
-					$state.go('userProfile', { id: result._id });
-				}, () => {
-					$scope.userCreated = false;
-				});
+      $scope.createUser = function(user) {
+        usersService.createUser(user).then((result) => {
+          $scope.userCreated = true;
+          $state.go('userProfile', { id: result._id });
+        }, () => {
+          $scope.userCreated = false;
+        });
 
-			};
-		}]);
+      };
+    }]);
 })();

--- a/test/fixtures/fixed-javascript.js
+++ b/test/fixtures/fixed-javascript.js
@@ -1,0 +1,19 @@
+'use strict';
+(() => {
+	onboarding.controller('createUserController', ['$scope', '$stateParams', '$state',
+		'usersService', function($scope, $stateParams, $state, usersService) {
+			for (let param of $stateParams) {
+				param.foo = 'foo';
+			}
+
+			$scope.createUser = function(user) {
+				usersService.createUser(user).then((result) => {
+					$scope.userCreated = true;
+					$state.go('userProfile', { id: result._id });
+				}, () => {
+					$scope.userCreated = false;
+				});
+
+			};
+		}]);
+})();

--- a/test/polymer-spec.js
+++ b/test/polymer-spec.js
@@ -1,13 +1,17 @@
 /* eslint no-console: "off" */
 'use strict';
 
+const fs = require('fs-extra');
+
 describe('polymer linter', () => {
 
 	const polymer = require('../linters/polymer');
 	const customMatchers = require('./helpers/custom-matchers');
 
-	const badFile  = __dirname + '/fixtures/bad-component.html';
+	const badFile = __dirname + '/fixtures/bad-component.html';
+	const badCode = fs.readFileSync(badFile, 'utf8');
 	const goodFile = __dirname + '/fixtures/good-component.html';
+	const goodCode = fs.readFileSync(goodFile, 'utf8');
 	const otherFile = __dirname + '/fixtures/good-html.html';
 
 	beforeEach(() => {
@@ -70,11 +74,70 @@ describe('polymer linter', () => {
 
 	});
 
+	describe('checkCode()', () => {
+
+		it('should return a promise with an array of errors', (done) => {
+			polymer.checkCode(badCode).then((results) => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBeGreaterThan(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should have the expected error signature', (done) => {
+			polymer.checkCode(badCode).then((results) => {
+				expect(results[0]).toBeLintError();
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should return a promise with an empty array for lint-free code', (done) => {
+			polymer.checkCode(goodCode).then((results) => {
+				expect(results).toEqual([]);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should accept options', (done) => {
+			const opts = {
+				// ignore all the errors
+				rules: {
+					'component-name-matches-filename': false,
+					'style-inside-template': false
+				}
+			};
+			polymer.checkCode(badCode, opts).then((results) => {
+				expect(results).toEqual([]);
+				done();
+			});
+		});
+
+	});
+
 	describe('fix()', () => {
 
 		it('should act like check()', (done) => {
 			polymer.fix(badFile).then((results) => {
 				expect(results).toEqual(jasmine.any(Array));
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+	});
+
+	describe('fixCode()', () => {
+
+		it('should return the same code', (done) => {
+			polymer.fixCode(badCode).then((results) => {
+				expect(results).toBe(badCode);
 				done();
 			}).catch((err) => {
 				console.log('Error:', err.stack);


### PR DESCRIPTION
Adds `checkCode()` and `fixCode()` to the Node API to allow a user to check/fix a string of code (rather than files). See the README changes for an overview.

This addition is required for using ux-lint inside IDE plugins, where code itself is analyzed and might not be tied to a filename yet.

cc @Banno/ux 

## How to Test

`npm run lint` and `npm test` should continue to pass.

## Notes

The `fix()` call runs the linters synchronously now, to prevent possible file-write conflicts from multiple linters simultaneously trying to fix a file. The `fixCode()` call also runs synchronously out of necessity (to pass the fixed code from one linter to the next).

