### PR TITLE
Allow a "language" option to be passed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ linter.fixCode('// code here', { /* optional config */ }, function(err, fixedCod
 });
 ```
 
+A `language` option can be passed in the options to specify the format of the code (`html` or `javascript`), so that the appropriate linters are run.
+
 ## Contributing
 
 Want to propose a change to our style (and therefore linting) conventions? Want to add another linting tool? Pull requests and suggestions are welcome.

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function runLinters(type, fileOrCode, opts, callback) {
 	// Function for normal linting & fixing files.
 	let lintByName = (linterName, callback) => {
 		let linterOpts = opts[linterName] || {};
+		linterOpts.language = opts.language;
 		linters[linterName][type](fileOrCode, linterOpts).then(result => {
 			callback(null, result);
 		}).catch((err) => {

--- a/linters/eslint.js
+++ b/linters/eslint.js
@@ -56,6 +56,9 @@ function linter(type, sourceType, filesOrCode, opts) {
 
 	let getSource = () => {
 		if (sourceType === 'text') {
+			if (opts.language && opts.language !== 'javascript') {
+				return Promise.resolve('');
+			}
 			return Promise.resolve(filesOrCode);
 		}
 

--- a/linters/htmlhint.js
+++ b/linters/htmlhint.js
@@ -28,6 +28,10 @@ exports.check = (filePattern, opts) => {
 
 exports.checkCode = (code, opts) => {
 	opts = Object.assign({}, config, opts);
+	if (opts.language && opts.language !== 'html') {
+		// Ignore non-HTML code.
+		return Promise.resolve([]);
+	}
 	return Promise.resolve(
 		lintHtml({
 			contents: code,

--- a/linters/polymer.js
+++ b/linters/polymer.js
@@ -72,7 +72,12 @@ function linter(sourceType, filesOrCode, opts) {
 	let getSource = () => {
 		if (sourceType === 'text') {
 			let stream = new PassThrough();
-			stream.end(filesOrCode);
+			if (opts.language && opts.language !== 'html') {
+				// Ignore non-HTML code.
+				stream.end();
+			} else {
+				stream.end(filesOrCode);
+			}
 			return Promise.resolve(stream);
 		}
 

--- a/test/api-spec.js
+++ b/test/api-spec.js
@@ -82,6 +82,17 @@ describe('JS API', () => {
 			});
 		});
 
+		it('should pass along the "language" option to the linters', done => {
+			const goodFile = __dirname + '/fixtures/good-component.html';
+			const goodCode = fs.readFileSync(goodFile, 'utf8');
+			linter.checkCode(goodCode, { language: 'html' }, (err, results) => {
+				if (err) { console.log('Error:', err.message); }
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			});
+		});
+
 	});
 
 	describe('fix()', () => {

--- a/test/eslint-spec.js
+++ b/test/eslint-spec.js
@@ -142,6 +142,26 @@ describe('eslint linter', () => {
 			});
 		});
 
+		it('should work when a language is defined', done => {
+			eslint.checkCode(goodCode, { language: 'javascript' }).then(results => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should ignore non-JS code', done => {
+			eslint.checkCode(badCode, { language: 'html' }).then(results => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
 	});
 
 	describe('fix()', () => {

--- a/test/htmlhint-spec.js
+++ b/test/htmlhint-spec.js
@@ -155,6 +155,26 @@ describe('html linter', () => {
 			});
 		});
 
+		it('should work when a language is defined', done => {
+			linter.checkCode(goodCode, { language: 'html' }).then(results => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should ignore non-HTML code', done => {
+			linter.checkCode(badCode, { language: 'javascript' }).then(results => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
 	});
 
 	describe('fix()', () => {

--- a/test/polymer-spec.js
+++ b/test/polymer-spec.js
@@ -118,6 +118,26 @@ describe('polymer linter', () => {
 			});
 		});
 
+		it('should work when a language is defined', done => {
+			polymer.checkCode(goodCode, { language: 'html' }).then(results => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should ignore non-HTML code', done => {
+			polymer.checkCode(badCode, { language: 'javascript' }).then(results => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
 	});
 
 	describe('fix()', () => {


### PR DESCRIPTION
To indicate HTML or Javascript for the `checkCode()` & `fixCode()` functions.

## To Test

`npm run lint` and `npm test`
