### PR TITLE
Lint the JS inside HTML <script> tags

### DIFF
--- a/config/eslint.hjson
+++ b/config/eslint.hjson
@@ -7,9 +7,10 @@
 		"protractor": true
 	},
 	"extends": "eslint:recommended",
-	"plugins": ["banno"],
+	"plugins": ["banno", "html"],
 	"globals": {
 		"angular": false,
+		"Polymer": false,
 		// Angular mocks
 		"inject": false,
 		"mock": false,
@@ -163,5 +164,9 @@
 		}],
 		"wrap-iife": ["error", "inside"], // require IIFEs to be wrapped in parens
 		"yield-star-spacing": ["error", "after"], // require space after "yield*"
-	}
+	},
+	"settings": {
+		"html/report-bad-indent": "error", // error if html/indent is bad
+		"html/indent": "+2", // <script> indentation plus two spaces
+	},
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chalk": "^1.1.1",
     "eslint": "^3.9.1",
     "eslint-plugin-banno": "^1.0.0",
+    "eslint-plugin-html": "^2.0.1",
     "extend": "^3.0.0",
     "globby": "^6.1.0",
     "hjson": "^2.4.1",

--- a/test/eslint-spec.js
+++ b/test/eslint-spec.js
@@ -18,6 +18,11 @@ describe('eslint linter', () => {
 	const goodFile = __dirname + '/fixtures/good-javascript.js';
 	const goodCode = fs.readFileSync(goodFile, 'utf8');
 	const htmlFile = __dirname + '/fixtures/good-html.html';
+	const htmlCode = fs.readFileSync(htmlFile, 'utf8');
+	const polymerFile = __dirname + '/fixtures/good-component.html';
+	const polymerCode = fs.readFileSync(polymerFile, 'utf8');
+	const cssFile = __dirname + '/fixtures/good-css.css';
+	const cssCode = fs.readFileSync(cssFile, 'utf8');
 
 	beforeEach(() => {
 		jasmine.addMatchers(customMatchers);
@@ -84,8 +89,28 @@ describe('eslint linter', () => {
 			});
 		});
 
-		it('should ignore non-JS files', done => {
+		it('should check scripts inside HTML files', done => {
 			eslint.check(htmlFile).then((results) => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBeGreaterThan(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should work with Polymer components', done => {
+			eslint.check(polymerFile).then((results) => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should ignore non-JS (and non-HTML) files', done => {
+			eslint.check(cssFile).then((results) => {
 				expect(results).toEqual(jasmine.any(Array));
 				expect(results.length).toBe(0);
 				done();
@@ -152,8 +177,28 @@ describe('eslint linter', () => {
 			});
 		});
 
+		it('should check scripts inside HTML code', done => {
+			eslint.checkCode(htmlCode, { language: 'html' }).then((results) => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBeGreaterThan(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
+		it('should work with Polymer components', done => {
+			eslint.checkCode(polymerCode, { language: 'html' }).then((results) => {
+				expect(results).toEqual(jasmine.any(Array));
+				expect(results.length).toBe(0);
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
+		});
+
 		it('should ignore non-JS code', done => {
-			eslint.checkCode(badCode, { language: 'html' }).then(results => {
+			eslint.checkCode(cssCode, { language: 'css' }).then(results => {
 				expect(results).toEqual(jasmine.any(Array));
 				expect(results.length).toBe(0);
 				done();

--- a/test/fixtures/good-component.html
+++ b/test/fixtures/good-component.html
@@ -6,8 +6,18 @@
     <div>test component</div>
   </template>
   <script>
+    'use strict';
+
     Polymer({
-      is: "good-component"
+      is: 'good-component'
     });
+
+    class MyElement extends Polymer.Element {
+      static get is() { return 'my-element'; }
+      ready() {
+        super.ready();
+      }
+    }
+    window.customElements.define(MyElement.is, MyElement);
   </script>
 </dom-module>

--- a/test/fixtures/good-css.css
+++ b/test/fixtures/good-css.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/test/fixtures/good-html.html
+++ b/test/fixtures/good-html.html
@@ -9,5 +9,8 @@
   <body>
     <div>Test file</div>
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"></svg>
+    <script>
+      this is invalid JS
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This extends the ESLint linter to check the JS code inside `<script>` tags. This closes https://github.com/Banno/banno-web/issues/798.

I also fixed up the config & code to work with the JS in a Polymer component.

## How To Test

* `npm run lint` and `npm test` should pass.
* Run it against the projects to see the kind of output it generates:
  * `node cli.js /path/to/banno-web/src/**/*.html`
  * `node cli.js /path/to/platform-ux/src/index.html /path/to/platform-ux/src/*/*.html`
