### PR TITLE
Custom rules for polymer lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project combines the following linting tools used by the Banno UX team into
 
 * [ESLint](http://eslint.org/) for JS files
 * [HTMLHint](https://github.com/yaniswang/HTMLHint) for HTML files, with [additional custom rules](docs/htmlhint.md)
-* [polymer-lint](https://github.com/Banno/polymer-lint) for Polymer component (HTML) files
+* [polymer-lint](https://github.com/Banno/polymer-lint) for Polymer component (HTML) files, with [additional custom rules](docs/polymer.md)
 
 ## Installation
 

--- a/docs/polymer.md
+++ b/docs/polymer.md
@@ -1,0 +1,13 @@
+# Custom polymer-lint Rules
+
+## `icon-titles`
+
+For accessibility, `jha-icon-*` components must have a `title` attribute.
+
+```html
+<!-- invalid -->
+<jha-icon-test></jha-icon-test>
+
+<!-- valid -->
+<jha-icon-test title="test"></jha-icon-test>
+```

--- a/linters/polymer.js
+++ b/linters/polymer.js
@@ -10,22 +10,22 @@ const config = parseJson(__dirname + '/../config/polymer.hjson');
 
 const customRules = {
 	'icon-titles': function iconTitles(context, parser, onError) {
-		  const iconRegExp = new RegExp(/jha-icon-[\w-]+/);
-		  parser.on('startTag', (name, attrs, selfClosing, location) => {
-		    if (
-		      !name.match(iconRegExp) ||
-		      (name.match(iconRegExp) &&
-		        attrs.filter(attr => attr.name === 'title').length)
-		    ) {
-		      return;
-		    }
-		    onError({
-		      message: `Icon has no title attribute: ${name}`,
-		      location
-		    });
-		  });
-		}
-}
+		const iconRegExp = new RegExp(/jha-icon-[\w-]+/);
+		parser.on('startTag', (name, attrs, selfClosing, location) => {
+			if (
+				!name.match(iconRegExp) ||
+				(name.match(iconRegExp) &&
+					attrs.filter(attr => attr.name === 'title').length)
+			) {
+				return;
+			}
+			onError({
+				message: `Icon has no title attribute: ${name}`,
+				location
+			});
+		});
+	}
+};
 
 exports.check = (filePattern, opts) => {
 	return linter('files', filePattern, opts);

--- a/linters/polymer.js
+++ b/linters/polymer.js
@@ -8,6 +8,25 @@ const { PassThrough } = require('stream');
 const allRules = require('polymer-lint/lib/rules');
 const config = parseJson(__dirname + '/../config/polymer.hjson');
 
+const customRules = {
+	'icon-titles': function iconTitles(context, parser, onError) {
+		  const iconRegExp = new RegExp(/jha-icon-[\w-]+/);
+		  parser.on('startTag', (name, attrs, selfClosing, location) => {
+		    if (
+		      !name.match(iconRegExp) ||
+		      (name.match(iconRegExp) &&
+		        attrs.filter(attr => attr.name === 'title').length)
+		    ) {
+		      return;
+		    }
+		    onError({
+		      message: `Icon has no title attribute: ${name}`,
+		      location
+		    });
+		  });
+		}
+}
+
 exports.check = (filePattern, opts) => {
 	return linter('files', filePattern, opts);
 };
@@ -35,7 +54,7 @@ function buildRules(rulesDefinition) {
 		});
 	} else {
 		// If no rules are specified, use the entire set.
-		rules = Object.assign({}, allRules);
+		rules = Object.assign({}, allRules, customRules);
 	}
 	return rules;
 }

--- a/test/fixtures/bad-component.html
+++ b/test/fixtures/bad-component.html
@@ -1,8 +1,8 @@
 <dom-module id="bad-test-component">
   <style></style>
   <template>
-		<div>test component</div>
-		<jha-icon-test></jha-icon-test>
+    <div>test component</div>
+    <jha-icon-test></jha-icon-test>
   </template>
   <script>
     Polymer({

--- a/test/fixtures/good-icon.html
+++ b/test/fixtures/good-icon.html
@@ -1,12 +1,12 @@
-<dom-module id="bad-test-component">
+<dom-module id="test-component">
   <style></style>
   <template>
 		<div>test component</div>
-		<jha-icon-test></jha-icon-test>
+		<jha-icon-test title="test"></jha-icon-test>
   </template>
   <script>
     Polymer({
-      is: "test-component-bad"
+      is: "test-component"
     });
   </script>
 </dom-module>

--- a/test/fixtures/good-icon.html
+++ b/test/fixtures/good-icon.html
@@ -1,10 +1,10 @@
 <dom-module id="test-component">
   <style></style>
   <template>
-		<div>test component</div>
-		<jha-icon-test title="test"></jha-icon-test>
-		<!-- bplint-disable icon-titles -->
-		<jha-icon-test></jha-icon-test>
+    <div>test component</div>
+    <jha-icon-test title="test"></jha-icon-test>
+    <!-- bplint-disable icon-titles -->
+    <jha-icon-test></jha-icon-test>
   </template>
   <script>
     Polymer({

--- a/test/fixtures/good-icon.html
+++ b/test/fixtures/good-icon.html
@@ -3,6 +3,8 @@
   <template>
 		<div>test component</div>
 		<jha-icon-test title="test"></jha-icon-test>
+		<!-- bplint-disable icon-titles -->
+		<jha-icon-test></jha-icon-test>
   </template>
   <script>
     Polymer({

--- a/test/polymer-spec.js
+++ b/test/polymer-spec.js
@@ -13,6 +13,7 @@ describe('polymer linter', () => {
 	const goodFile = __dirname + '/fixtures/good-component.html';
 	const goodCode = fs.readFileSync(goodFile, 'utf8');
 	const otherFile = __dirname + '/fixtures/good-html.html';
+	const goodIcon = __dirname + '/fixtures/good-icon.html';
 
 	beforeEach(() => {
 		jasmine.addMatchers(customMatchers);
@@ -72,6 +73,25 @@ describe('polymer linter', () => {
 			});
 		});
 
+	 it('should include icon-titles rule', done => {
+		polymer.check(badFile).then((results) => {
+			const errorCodes = results.map(r => r.code);
+			expect(errorCodes).toContain('icon-titles');
+			done();
+		}).catch((err) => {
+			console.log('Error:', err.stack);
+		});
+	 })
+
+	 it('should include icon-titles rule, without false positives', done => {
+		polymer.check(goodIcon).then((results) => {
+			const errorCodes = results.map(r => r.code);
+			expect(errorCodes).not.toContain('icon-titles');
+			done();
+		}).catch((err) => {
+			console.log('Error:', err.stack);
+		});
+	 })
 	});
 
 	describe('checkCode()', () => {

--- a/test/polymer-spec.js
+++ b/test/polymer-spec.js
@@ -73,25 +73,25 @@ describe('polymer linter', () => {
 			});
 		});
 
-	 it('should include icon-titles rule', done => {
-		polymer.check(badFile).then((results) => {
-			const errorCodes = results.map(r => r.code);
-			expect(errorCodes).toContain('icon-titles');
-			done();
-		}).catch((err) => {
-			console.log('Error:', err.stack);
+		it('should include icon-titles rule', done => {
+			polymer.check(badFile).then((results) => {
+				const errorCodes = results.map(r => r.code);
+				expect(errorCodes).toContain('icon-titles');
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
 		});
-	 })
 
-	 it('should include icon-titles rule, without false positives', done => {
-		polymer.check(goodIcon).then((results) => {
-			const errorCodes = results.map(r => r.code);
-			expect(errorCodes).not.toContain('icon-titles');
-			done();
-		}).catch((err) => {
-			console.log('Error:', err.stack);
+		it('should include icon-titles rule, without false positives', done => {
+			polymer.check(goodIcon).then((results) => {
+				const errorCodes = results.map(r => r.code);
+				expect(errorCodes).not.toContain('icon-titles');
+				done();
+			}).catch((err) => {
+				console.log('Error:', err.stack);
+			});
 		});
-	 })
 	});
 
 	describe('checkCode()', () => {


### PR DESCRIPTION
## What it does
this PR adds a rule that checks to make sure any instance of jha-icon-* includes a title attribute.  

The implementation is pretty simple.. it just looks for a tag named `jha-icon-*` (uses regex to check the wildcard) and makes sure the title attribute is present.

## Caveats
I should mention that adding this rule will create a lot of linter errors in banno-online because there ARE some icons that do not have titles (_intentionally_).. so someone (prolly me...) will have to go through and manually disable the linter for those icons.