### PR TITLE
eslint-plugin-html config to lint <script type="module">

### DIFF
--- a/config/eslint.hjson
+++ b/config/eslint.hjson
@@ -168,5 +168,8 @@
 	"settings": {
 		"html/report-bad-indent": "error", // error if html/indent is bad
 		"html/indent": "+2", // <script> indentation plus two spaces
+		// lint JavaScript inside <script> tags with no `type` attribute, `type="module"`,
+		// or `type="application/javascript"`
+		"html/javascript-mime-types": "/^(module|application/javascript)$/",
 	},
 }

--- a/test/eslint-spec.js
+++ b/test/eslint-spec.js
@@ -13,16 +13,21 @@ describe('eslint linter', () => {
 
 	const badFile  = __dirname + '/fixtures/bad-javascript.js';
 	const badCode  = fs.readFileSync(badFile, 'utf8');
-	const fixedFile = __dirname + '/fixtures/fixed-javascript.js';
-	const fixedCode = fs.readFileSync(fixedFile, 'utf8');
-	const goodFile = __dirname + '/fixtures/good-javascript.js';
-	const goodCode = fs.readFileSync(goodFile, 'utf8');
-	const htmlFile = __dirname + '/fixtures/good-html.html';
-	const htmlCode = fs.readFileSync(htmlFile, 'utf8');
-	const polymerFile = __dirname + '/fixtures/good-component.html';
-	const polymerCode = fs.readFileSync(polymerFile, 'utf8');
+
 	const cssFile = __dirname + '/fixtures/good-css.css';
 	const cssCode = fs.readFileSync(cssFile, 'utf8');
+
+	const fixedFile = __dirname + '/fixtures/fixed-javascript.js';
+	const fixedCode = fs.readFileSync(fixedFile, 'utf8');
+
+	const goodFile = __dirname + '/fixtures/good-javascript.js';
+	const goodCode = fs.readFileSync(goodFile, 'utf8');
+
+	const jsInHtmlFile = __dirname + '/fixtures/javascript-in-html.html';
+	const jsInHtmlCode = fs.readFileSync(jsInHtmlFile, 'utf8');
+
+	const polymerFile = __dirname + '/fixtures/good-component.html';
+	const polymerCode = fs.readFileSync(polymerFile, 'utf8');
 
 	beforeEach(() => {
 		jasmine.addMatchers(customMatchers);
@@ -90,9 +95,9 @@ describe('eslint linter', () => {
 		});
 
 		it('should check scripts inside HTML files', done => {
-			eslint.check(htmlFile).then((results) => {
-				expect(results).toEqual(jasmine.any(Array));
-				expect(results.length).toBeGreaterThan(0);
+			eslint.check(jsInHtmlFile).then((results) => {
+				const codes = results.map(({ code }) => code);
+				expect(codes).toEqual(['no-undef', 'no-console']);
 				done();
 			}).catch((err) => {
 				console.log('Error:', err.stack);
@@ -178,9 +183,9 @@ describe('eslint linter', () => {
 		});
 
 		it('should check scripts inside HTML code', done => {
-			eslint.checkCode(htmlCode, { language: 'html' }).then((results) => {
-				expect(results).toEqual(jasmine.any(Array));
-				expect(results.length).toBeGreaterThan(0);
+			eslint.checkCode(jsInHtmlCode, { language: 'html' }).then((results) => {
+				const codes = results.map(({ code }) => code);
+				expect(codes).toEqual(['no-undef', 'no-console']);
 				done();
 			}).catch((err) => {
 				console.log('Error:', err.stack);

--- a/test/fixtures/javascript-in-html.html
+++ b/test/fixtures/javascript-in-html.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>test</title>
+  </head>
+  <body>
+    <script>
+      'use strict';
+      MyGlobal = 'This is valid JavaScript with a \'no-undef\' error';
+    </script>
+
+    <script type="module">
+      console.warn('This is valid JavaScript with a \'no-console\' error.');
+    </script>
+
+    <script type="text/coffeescript">
+      This is not JavaScript and should be ignored.
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
By default eslint-plugin-html does not lint JavaScript code in [`<script type="module">`](https://blog.whatwg.org/js-modules) tags. This PR configures the `"html/javascript-mime-types"` option to lint code in tags with `type="application/javascript"`, `type="module"`, or no `type`.